### PR TITLE
feat: generate rules script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+oxlint_rules.json

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "bun --hot src/index.tsx",
     "build": "bun build ./src/index.html --outdir=dist --sourcemap --target=browser --minify --define:process.env.NODE_ENV='\"production\"' --env='BUN_PUBLIC_*'",
     "start": "NODE_ENV=production bun src/index.tsx",
-    "lint": "oxlint --type-aware"
+    "lint": "oxlint --type-aware",
+    "generate": "./scripts/rule_parser.sh"
   },
   "dependencies": {
     "react": "^19",

--- a/scripts/rule_parser.sh
+++ b/scripts/rule_parser.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+OXLINT_BIN="./node_modules/.bin/oxlint"
+
+if [ ! -x "$OXLINT_BIN" ]; then
+    echo "Oxlint not found. Please install project dependencies." >&2
+    exit 1
+fi
+
+$($OXLINT_BIN --rules | awk '
+BEGIN {
+    print "["
+    ORS = ",\n"
+    first_record = 1
+    category = ""
+}
+
+/^## / {
+    category = $2
+}
+
+/^\| [a-z]/ {
+    if (first_record == 1) {
+        first_record = 0
+    } else {
+        printf ORS
+    }
+
+    printf "  {\n"
+    printf "    \"name\": \"%s\",\n", $2
+    printf "    \"source\": \"%s\",\n", $4
+    printf "    \"category\": \"%s\"\n", category
+    printf "  }"
+}
+
+END {
+    printf "\n]\n"
+}
+' > oxlint_rules.json)


### PR DESCRIPTION
### what

- create a bash script that runs the `oxlint --rules` command and parses and writes the output to a json file

**part of what the generated file looks like:**
```json
[
  {
    "name": "for-direction",
    "source": "eslint",
    "category": "Correctness"
  },
  {
    "name": "no-async-promise-executor",
    "source": "eslint",
    "category": "Correctness"
  },
  {
    "name": "no-caller",
    "source": "eslint",
    "category": "Correctness"
  }
]
```

### why

- the list can be used to render all rules in the ui

### how to test

1. run `bun run generate`
2. check the output in `oxlint_rules.json`

### notes
i chose to add the output file to `.gitignore` and create a script in `package.json` thinking this process could later be automated in pipelines or similar