### PR TITLE
feat: run all rules and track hit count

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Configuring linters often involves jumping between your editor, a massive JSON f
 - **Non-Destructive**: Toggling rules happens entirely in memory. No changes are written to disk, making it safe to experiment without messing up your config or comments.
 - **Config Aware**: Automatically reads `.oxlintrc.json` to initialize the state, but works perfectly even if no config file exists.
 - **Details**: View category, scope, fix, default, and type-aware rule parameters at a glance.
+- **Hit Counts**: See exactly how many violations each rule triggers in your codebase. Hits are displayed next to the rule name (e.g., `no-debugger (3)`) and highlighted for clarity.
+- **Run All**: Quickly run every available rule (even those turned off) to see what else might be lurking in your code.
 - **View Docs**: Press <kbd>ENTER</kbd> on any rule to open its official documentation in your browser.
 - **Zero Dependencies**: Written in pure Node.js without any heavy TUI libraries.
 
@@ -59,8 +61,9 @@ oxlint-tui
 | **1**           | Set selected rule to "off"              |
 | **2**           | Set selected rule to "warn"             |
 | **3**           | Set selected rule to "error"            |
-| **x**           | Run "oxlint" with the selected rule     |
-| **r**           | Run "oxlint with all enabled rules      |
+| **x**           | Run linter with the selected rule only  |
+| **r**           | Run linter with all activated rules     |
+| **a**           | Run linter with ALL available rules     |
 | **Enter**       | Open Rule Documentation in Browser      |
 | **q** / **Esc** | Quit                                    |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,4 +20,5 @@ export const KEY_MAP: Record<string, Action> = {
   q: { type: "EXIT" },
   r: { type: "RUN_LINT" },
   x: { type: "RUN_SINGLE_RULE" },
+  a: { type: "RUN_ALL_RULES" },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,20 +53,24 @@ function updateConfig(rule: OxlintRule, newStatus: RuleStatus): void {
   }
 }
 
-function runLint({ rule = null }: { rule?: OxlintRule | null } = {}): void {
+function runLint({
+  rule = null,
+  isRunAll = false,
+}: { rule?: OxlintRule | null; isRunAll?: boolean } = {}): void {
   if (state.isLintInProgress) return;
 
   state.isLintInProgress = true;
 
   let ruleName = rule ? `${rule.scope}/${rule.value}` : null;
 
-  const typeAware = rule
-    ? rule.type_aware
-    : Object.values(state.rulesByCategory)
-        .flat()
-        .some((ruleItem) => ruleItem.isActive && ruleItem.type_aware === true);
+  const typeAware =
+    rule || isRunAll
+      ? true
+      : Object.values(state.rulesByCategory)
+          .flat()
+          .some((ruleItem) => ruleItem.isActive && ruleItem.type_aware === true);
 
-  state.message = "Linting";
+  state.message = isRunAll ? "Running all rules" : "Linting";
   if (ruleName) state.message += ` [${ruleName}]`;
   if (typeAware) state.message += " with --type-aware";
   state.message += "...";
@@ -88,11 +92,13 @@ function runLint({ rule = null }: { rule?: OxlintRule | null } = {}): void {
     args.push("--type-aware");
   }
 
-  if (ruleName) {
+  args.push("--format=json");
+
+  if (isRunAll) {
+    args.push("-A", "all", "-W", "all");
+  } else if (ruleName) {
     args.push("-A", "all", "-D", ruleName);
   } else if (state.config && state.config.rules) {
-    // Convert in-memory config object to CLI arguments
-    // -D = Deny (Error), -W = Warn, -A = Allow (Off)
     Object.entries(state.config.rules).forEach(([key, status]) => {
       const val = Array.isArray(status) ? status[0] : status;
       if (val === "error") args.push("-D", key);
@@ -113,26 +119,51 @@ function runLint({ rule = null }: { rule?: OxlintRule | null } = {}): void {
     stderrData += data;
   });
 
-  child.on("close", (code) => {
+  child.on("close", (_code) => {
     state.isLintInProgress = false;
 
-    const fullOutput = stdoutData + stderrData;
-    const summaryMatch = fullOutput.match(/Found (\d+) warnings? and (\d+) errors?/i);
+    try {
+      const output = JSON.parse(stdoutData || "{}");
+      const diagnostics = output.diagnostics || [];
+      const hitCounts: Record<string, number> = {};
 
-    if (summaryMatch) {
-      const errors = parseInt(summaryMatch[2]);
-      state.message = ruleName
-        ? `[${ruleName}] Found ${errors} issue${errors === 1 ? "" : "s"}`
-        : summaryMatch[0];
-      state.messageType = errors > 0 ? "error" : "warn";
-    } else if (
-      stdoutData.toLowerCase().includes("finished") ||
-      (code === 0 && stdoutData.length < 200)
-    ) {
-      state.message = "Linting passed! 0 issues found.";
-      if (ruleName) state.message = `[${ruleName}] ${state.message}`;
-      state.messageType = "success";
-    } else {
+      diagnostics.forEach((d: any) => {
+        const code = d.code;
+        hitCounts[code] = (hitCounts[code] || 0) + 1;
+      });
+
+      Object.keys(state.rulesByCategory).forEach((cat) => {
+        state.rulesByCategory[cat].forEach((r) => {
+          r.hits = 0;
+        });
+      });
+
+      Object.entries(hitCounts).forEach(([code, count]) => {
+        let ruleToUpdate: OxlintRule | undefined;
+        Object.values(state.rulesByCategory).some((rules) => {
+          ruleToUpdate = rules.find((r) => {
+            if (code === r.value) return true;
+            if (code === `${r.scope}/${r.value}`) return true;
+            if (code === `${r.scope}(${r.value})`) return true;
+            if (code.endsWith(`(${r.value})`)) return true;
+            return false;
+          });
+          return !!ruleToUpdate;
+        });
+        if (ruleToUpdate) ruleToUpdate.hits = count;
+      });
+
+      const errors = diagnostics.filter((d: any) => d.severity === "error").length;
+      const warnings = diagnostics.filter((d: any) => d.severity === "warning").length;
+
+      if (diagnostics.length > 0) {
+        state.message = `Found ${warnings} warning${warnings === 1 ? "" : "s"} and ${errors} error${errors === 1 ? "" : "s"}`;
+        state.messageType = errors > 0 ? "error" : "warn";
+      } else {
+        state.message = "Linting passed! 0 issues found.";
+        state.messageType = "success";
+      }
+    } catch {
       const cleanError = stderrData
         .split("\n")
         .filter(
@@ -143,6 +174,7 @@ function runLint({ rule = null }: { rule?: OxlintRule | null } = {}): void {
       state.message = cleanError ? `Error: ${cleanError.substring(0, 50)}...` : "Lint failed";
       state.messageType = "error";
     }
+
     render();
   });
 }
@@ -166,6 +198,10 @@ function execute(action: Action | null): void {
 
     case "RUN_LINT":
       runLint();
+      return;
+
+    case "RUN_ALL_RULES":
+      runLint({ isRunAll: true });
       return;
 
     case "RUN_SINGLE_RULE": {

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -51,7 +51,7 @@ function drawBox(
   items.slice(scrollOffset, scrollOffset + innerHeight).forEach((item, i) => {
     const absoluteIndex = scrollOffset + i;
     const isRule = typeof item !== "string";
-    const rawText = isRule ? item.value : item;
+    const rawText = isRule ? (item.hits ? `${item.value} (${item.hits})` : item.value) : item;
 
     let display =
       rawText.length > width - 4
@@ -64,6 +64,10 @@ function drawBox(
       if (ruleItem.configStatus === "error") itemColor = COLORS.error;
       else if (ruleItem.configStatus === "warn") itemColor = COLORS.warn;
       else if (ruleItem.isActive) itemColor = COLORS.success;
+
+      if (ruleItem.hits && ruleItem.hits > 0) {
+        itemColor = COLORS.highlight;
+      }
     }
 
     buffer.push(`\x1b[${y + 1 + i};${x + 2}H`);
@@ -253,7 +257,7 @@ export function render(): void {
 
   const footerConfig = state.configPath ? `Config: ${state.configPath}` : "No config loaded";
   buffer.push(
-    `\x1b[${rows - 1};2H${COLORS.dim}Arrows/HJKL: Nav | 1-3: Status | R: Lint | X: Run rule | Enter: Docs | Q: Quit | ${footerConfig}${COLORS.reset}`,
+    `\x1b[${rows - 1};2H${COLORS.dim}Arrows/HJKL: Nav | 1-3: Status | R: Active | A: All | X: Rule | Enter: Docs | Q: Quit | ${footerConfig}${COLORS.reset}`,
   );
 
   stdout.write(buffer.join(""));

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type OxlintRule = {
   configStatus: RuleStatus;
   isActive: boolean;
   description?: string;
+  hits?: number;
 };
 
 export type OxlintConfig = {
@@ -45,6 +46,7 @@ export type ActionType =
   | "OPEN_DOCS"
   | "EXIT"
   | "RUN_LINT"
+  | "RUN_ALL_RULES"
   | "RUN_SINGLE_RULE"
   | "SET_STATUS";
 


### PR DESCRIPTION
- Adds the ability to run all available rules by pressing "a".
- After rules are run (by a, r, or x) a number indicating code violations is appended to the rule name.